### PR TITLE
Replace variables in replyToName and replyToMail

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -428,7 +428,9 @@ class SendMailService
             'receiverEmail',
             'senderName',
             'senderEmail',
-            'subject'
+            'subject',
+            'replyToName',
+            'replyToEmail'
         ];
         foreach ($parse as $value) {
             $email[$value] = TemplateUtility::fluidParseString(


### PR DESCRIPTION
replyToName and replyToEmail supposedly support variable replacement, but they don't.

This patch fixes this.